### PR TITLE
Process API Testing

### DIFF
--- a/src/ProcessAPIImpl.java
+++ b/src/ProcessAPIImpl.java
@@ -36,4 +36,13 @@ public class ProcessAPIImpl implements ProcessInterface {
 		// return ds.readFromInput();
 		return null;
 	}
+
+	// Gets here to create sanity test, will fail, DSS and CE don't exist yet
+	public DataStorage getDSS() {
+		return null;
+	}
+
+	public ComputeEngine getCE() {
+		return null;
+	}
 }

--- a/src/ProcessAPIImpl.java
+++ b/src/ProcessAPIImpl.java
@@ -1,0 +1,39 @@
+import process.api.ComputeEngine;
+import process.api.DSCode;
+import process.api.DataStorage;
+import process.api.InputSource;
+import process.api.OutputSource;
+import process.api.ProcessAPI;
+import process.api.ProcessInterface;
+
+public class ProcessAPIImpl implements ProcessInterface {
+	// Empty Implementation with instance of API
+	// works between the DSS and the CE for input
+	// and output
+	// Since DSS and CE aren't classes yet methods return null
+	ProcessAPI processAPI;
+
+	public ProcessAPIImpl(ProcessAPI p) {
+		this.processAPI = p;
+	}
+
+	public InputSource getInputSrc(ComputeEngine ce) {
+		// return ce.getInputSrc();
+		return null;
+	}
+
+	public OutputSource getOutputSrc(ComputeEngine ce) {
+		// return ce.getOutputSrc();
+		return null;
+	}
+
+	public DSCode writeToOutput(DataStorage ds) {
+		// return ds.writeToOutput();
+		return null;
+	}
+
+	public DSCode readFromInput(DataStorage ds) {
+		// return ds.readFromInput();
+		return null;
+	}
+}

--- a/src/process/api/DSCode.java
+++ b/src/process/api/DSCode.java
@@ -1,14 +1,13 @@
 package process.api;
 
-public enum DSCode {
-	SUCCESS(1, true),
-	FALIURE(0, false);
+public interface DSCode {
+	static DSCode SUCCESS = () -> DSCodeStatus.SUCESSS;
+	static DSCode FAILURE = () -> DSCodeStatus.FAILURE;
 	
-	private final int id;
-	private final boolean success;
+	DSCodeStatus getStatus();
 	
-	private DSCode(int id, boolean success){
-		this.id = id;
-		this.success = success;
+	public static enum DSCodeStatus{
+		SUCESSS,
+		FAILURE;
 	}
 }

--- a/src/process/api/ProcessAPI.java
+++ b/src/process/api/ProcessAPI.java
@@ -1,14 +1,14 @@
 package process.api;
 
-public class PrototypeProcess {
-	public void prototype(ComputeEngine ce, DataStorage ds){
-		//get input src from CE
+public class ProcessAPI {
+	public void prototype(ComputeEngine ce, DataStorage ds) {
+		// get input src from CE
 		InputSource input = ce.getInputSrc(ce);
-		//get output src from CE
+		// get output src from CE
 		OutputSource output = ce.getOutputSrc(ce);
-		//write to Output
+		// write to Output
 		DSCode outputCode = ds.writeToOutput(output);
-		//read from Input
+		// read from Input
 		DSCode inputCode = ds.readFromInput(input);
 	}
 }

--- a/src/process/api/ProcessInterface.java
+++ b/src/process/api/ProcessInterface.java
@@ -1,6 +1,11 @@
 package process.api;
 
 public interface ProcessInterface {
-	//works between the DSS and the CE for input
-	//and output
+	InputSource getInputSrc(ComputeEngine ce);
+
+	OutputSource getOutputSrc(ComputeEngine ce);
+
+	DSCode readFromInput(DataStorage ds);
+
+	DSCode writeToOutput(DataStorage ds);
 }

--- a/test/TestProcessAPI.java
+++ b/test/TestProcessAPI.java
@@ -1,17 +1,25 @@
-import process.api.ProcessAPI;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
 
-public class ProcessAPITests {
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import process.api.ComputeEngine;
+import process.api.DataStorage;
+import process.api.ProcessAPI;
+
+public class TestProcessAPI {
 	private ProcessAPI mockProcApi = mock(ProcessAPI.class);
-	private ProcessAPIImpl procApi = new ProcessAPIImpl(mockProcAPI);
-	//I cannot get any mockito or Junit methods to be recognized within this class
-	//ProcessAPI depends on an object of DSS and CE
+	private ProcessAPIImpl procApi = new ProcessAPIImpl(mockProcApi);
+
+	// ProcessAPI depends on an object of DSS and CE
 	@Test
-	public void testDSS()
-	{
-		Assertions.assertEquals();
+	public void testDSS() {
+		Assertions.assertEquals(procApi.getDSS(), DataStorage.class, "Failed to verify existence of DSS");
 	}
+
 	@Test
-	public void testCE()
-	{}
+	public void testCE() {
+		Assertions.assertEquals(procApi.getCE(), ComputeEngine.class, "Failed to verify existence of CE");
+
+	}
 }

--- a/test/TestProcessAPI.java
+++ b/test/TestProcessAPI.java
@@ -1,0 +1,17 @@
+import process.api.ProcessAPI;
+import org.mockito.Mockito;
+
+public class ProcessAPITests {
+	private ProcessAPI mockProcApi = mock(ProcessAPI.class);
+	private ProcessAPIImpl procApi = new ProcessAPIImpl(mockProcAPI);
+	//I cannot get any mockito or Junit methods to be recognized within this class
+	//ProcessAPI depends on an object of DSS and CE
+	@Test
+	public void testDSS()
+	{
+		Assertions.assertEquals();
+	}
+	@Test
+	public void testCE()
+	{}
+}

--- a/test/emptyfile
+++ b/test/emptyfile
@@ -1,1 +1,0 @@
-you guys can delete this file. Just did it to committ the test folder. 


### PR DESCRIPTION
Issue with Mockito and Junit was resolved by adding the eclipse plugin to build.gradle and running the eclpise command with gradlew. Tests to verify the existence of dependencies for process API, CE and DSS. These are not currently implemented so the tests will fail. 